### PR TITLE
WIP/Suggestion: Add KV queues & ViewStateRepository to example

### DIFF
--- a/lib/api_schema.ts
+++ b/lib/api_schema.ts
@@ -305,10 +305,10 @@ export const commandMetadataSchema = z.object({
 });
 // Event metadata
 export const eventMetadataSchema = z.object({
-  tenant: z.string(),
+  // tenant: z.string(),
   eventId: z.string(),
   commandId: z.string(),
-  offset: z.number(),
+  // offset: z.number(),
 });
 // Query metadata
 export const queryMetadataSchema = z.object({

--- a/server.ts
+++ b/server.ts
@@ -2,17 +2,45 @@ import { blue } from "std/fmt/colors.ts";
 import {
   type Order,
   orderDecider,
+  orderView,
   type Restaurant,
   restaurantDecider,
+  restaurantView,
 } from "./lib/domain.ts";
-import { type Decider, EventSourcingAggregate } from "fmodel";
+import { type Decider, EventSourcingAggregate, MaterializedView } from "fmodel";
 import {
   type CommandMetadata,
   DenoEventRepository,
+  DenoViewStateRepository,
+  type EventMetadata,
 } from "./lib/infrastructure.ts";
-import type { ApplicationAggregate } from "./lib/application.ts";
-import { commandAndMetadataSchema } from "./lib/api_schema.ts";
+import type {
+  ApplicationAggregate,
+  ApplicationMaterializedView,
+} from "./lib/application.ts";
+import {
+  commandAndMetadataSchema,
+  eventAndMetadataSchema,
+} from "./lib/api_schema.ts";
 import type { Command, Event } from "./lib/api.ts";
+
+const kv = await Deno.openKv(":memory:");
+kv.listenQueue(async (raw) => {
+  try {
+    const event: Event & EventMetadata = eventAndMetadataSchema.parse(raw);
+    console.log(blue("Handling event: "), event);
+    const readRepository = new DenoViewStateRepository(kv);
+    const view = restaurantView.combine(orderView);
+    const materializedView: ApplicationMaterializedView = new MaterializedView(
+      view,
+      readRepository,
+    );
+    const result = await materializedView.handle(event);
+    console.log(blue("Result of event handling: "), result);
+  } catch (error) {
+    console.error("Error of event handling: ", error);
+  }
+});
 
 // A simple HTTP server that handles commands of all types
 Deno.serve(async (request: Request) => {
@@ -25,12 +53,11 @@ Deno.serve(async (request: Request) => {
     console.log(blue("Handling command: "), command);
 
     // Open the key-value store
-    const kv = await Deno.openKv("./db.sqlite3");
     // Combine deciders to create a new decider that can handle both restaurant and order commands
     const decider: Decider<Command, (Order & Restaurant) | null, Event> =
       restaurantDecider.combine(orderDecider);
     // Create a repository for the events / a Deno implementation of the IEventRepository
-    const eventRepository = new DenoEventRepository(kv);
+    const eventRepository = new DenoEventRepository(kv, true);
     // Create an aggregate to handle the commands of all types / Aggregate is composed of a decider and an event repository
     const aggregate: ApplicationAggregate = new EventSourcingAggregate(
       decider,

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { blue } from "std/fmt/colors.ts";
+import { blue, red } from "std/fmt/colors.ts";
 import {
   type Order,
   orderDecider,
@@ -24,21 +24,31 @@ import {
 } from "./lib/api_schema.ts";
 import type { Command, Event } from "./lib/api.ts";
 
+// Open the key-value store: running in-memory
 const kv = await Deno.openKv(":memory:");
+
+// Listen to events from kv queue and apply them to the materialized view
+// retry policy can specified on kv.enqueue method (optionally enabled in the DenoEventRepository)
 kv.listenQueue(async (raw) => {
   try {
+    // Parse the event and metadata from the raw data / Zod validation/parsing
     const event: Event & EventMetadata = eventAndMetadataSchema.parse(raw);
     console.log(blue("Handling event: "), event);
-    const readRepository = new DenoViewStateRepository(kv);
+    // Combine views to create a new view that can handle both restaurant and order events
     const view = restaurantView.combine(orderView);
+    // Create a repository for the view state / a Deno implementation of the IViewStateRepository
+    const readRepository = new DenoViewStateRepository(kv);
+    // Create a materialized view to handle the events of all types / MaterializedView is composed of a view and a read repository
     const materializedView: ApplicationMaterializedView = new MaterializedView(
       view,
       readRepository,
     );
+    // Handle the events of all types
     const result = await materializedView.handle(event);
     console.log(blue("Result of event handling: "), result);
   } catch (error) {
-    console.error("Error of event handling: ", error);
+    // Catch & no throw to prevent queue retries
+    console.log(red("Error of event handling: "), error);
   }
 });
 
@@ -52,11 +62,10 @@ Deno.serve(async (request: Request) => {
 
     console.log(blue("Handling command: "), command);
 
-    // Open the key-value store
     // Combine deciders to create a new decider that can handle both restaurant and order commands
     const decider: Decider<Command, (Order & Restaurant) | null, Event> =
       restaurantDecider.combine(orderDecider);
-    // Create a repository for the events / a Deno implementation of the IEventRepository
+    // Create a repository for the events / a Deno implementation of the IEventRepository and optionally enable event enqueueing
     const eventRepository = new DenoEventRepository(kv, true);
     // Create an aggregate to handle the commands of all types / Aggregate is composed of a decider and an event repository
     const aggregate: ApplicationAggregate = new EventSourcingAggregate(
@@ -72,7 +81,7 @@ Deno.serve(async (request: Request) => {
     });
   } catch (error) {
     console.error("Error of command handling: ", error);
-    return new Response(error?.message ?? error, {
+    return new Response((error as Error)?.message ?? error, {
       headers: { "Content-Type": "application/json" },
       status: 500,
     });

--- a/server.ts
+++ b/server.ts
@@ -24,8 +24,8 @@ import {
 } from "./lib/api_schema.ts";
 import type { Command, Event } from "./lib/api.ts";
 
-// Open the key-value store: running in-memory
-const kv = await Deno.openKv(":memory:");
+// Open the key-value store
+const kv = await Deno.openKv("./db.sqlite3");
 
 // Listen to events from kv queue and apply them to the materialized view
 // retry policy can specified on kv.enqueue method (optionally enabled in the DenoEventRepository)


### PR DESCRIPTION
Hi,
I think it'd be great to add an example of a view state repository & materialized view for the deno kv repo.
This is just an initial stab using kv to enqueue the events as part of the same atomic transaction when being saved, having them be picked up, updating stored state & logging the results.
